### PR TITLE
fix: golang init no longer nests everything under src/

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ The `install.sh` script will create a `~/.codeseed` binary, you will have to exp
  ```
 
 #### Windows
-Currently the `install.sh` only works with unix like systems for windows run `python3 -m PyInstaller --onefile codeseed.py` 
+Currently the `install.sh` only works with unix like systems for windows run `python3 -m PyInstaller --onefile --add-data "templates;templates" codeseed.py`
 this will create a `dist` folder. Add the path to the `dist` folder to your Environment variables and restart your machine and you are good to go.
+
+> [!NOTE] *The `--add-data` flag is required — codeseed's generated file content lives in `templates/`, not hardcoded in the script, so the binary needs it bundled to work.*
 
 ## Usage
 Using CodeSeed is very easy. You just need to call codeseed on your terminal and add the name of the Backend project you want to create. Like the following.
@@ -84,6 +86,30 @@ codeseed init --language golang --url git@github.com:sabi1125/CodeSeed.git
 | ------     | ------------------------------------------------------- | ------------------------------------------ |
 | init       | Creates new project                                     | `codeseed init <project-name> --<options>` |
 | create     | Creates the controller, interactor and repository files | `codeseed create <filename>`               |
+
+### Project layout by language
+
+**typescript** keeps the original flat layout: everything under `src/` (`src/controller`, `src/repository`, `src/interfaces/interactor`, ...).
+
+**golang** does not use a `src/` layer — `go.mod` and `cmd/<project-name>/main.go` live at the project root, matching normal Go convention:
+
+```
+cmd/<project-name>/main.go
+internal/
+  controller/
+  domain/
+    entities/
+    interactor/
+      inputport/
+        mock/
+    repository/
+      inputport/
+        mock/
+  infrastructure/
+  response/
+  log/
+  util/
+```
 
 ## Options
 ### Init argument options:

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from utils import templates
+
 def create_dotfiles(args):
     config = {
         "language": args.language,
@@ -14,16 +16,41 @@ def create_dotfiles(args):
 
 # create folders
 def create_folders(args):
-    folder_paths = [
-        '/src', 
-        '/src/controller',
-        '/src/domain',
-        '/src/interfaces',
-        '/src/infrastructure',
-        '/src/interfaces/interactor',
-        '/src/repository',
-        '/src/model'
-    ]
+    if args.language == 'golang':
+        # golang doesn't use a src/ layer — go.mod and cmd/ live at project root.
+        # domain/interactor and domain/repository each carry an inputport/ (the
+        # interface the layer above depends on, not the concrete type) plus an
+        # inputport/mock/ for generated mocks — dependency inversion, not just
+        # controller/interactor/repository as flat siblings.
+        folder_paths = [
+            '/cmd',
+            '/cmd/' + args.foldername,
+            '/internal',
+            '/internal/controller',
+            '/internal/domain',
+            '/internal/domain/entities',
+            '/internal/domain/interactor',
+            '/internal/domain/interactor/inputport',
+            '/internal/domain/interactor/inputport/mock',
+            '/internal/domain/repository',
+            '/internal/domain/repository/inputport',
+            '/internal/domain/repository/inputport/mock',
+            '/internal/infrastructure',
+            '/internal/response',
+            '/internal/log',
+            '/internal/util'
+        ]
+    else:
+        folder_paths = [
+            '/src',
+            '/src/controller',
+            '/src/domain',
+            '/src/interfaces',
+            '/src/infrastructure',
+            '/src/interfaces/interactor',
+            '/src/repository',
+            '/src/model'
+        ]
 
     list_of_directory = os.listdir("./")
     dir_already_exists = False
@@ -73,9 +100,7 @@ def create_files(args):
     
 
     if args.language == 'golang':
-        os.chdir('./src')
         os.system('go mod init ' + args.foldername)
-        os.chdir('..')
         return 'DONE'
 
 
@@ -107,6 +132,13 @@ def create_dockerfile(args):
 
 # create serverfile
 def create_server(args):
+    if args.language == 'golang':
+        os.chdir('cmd/' + args.foldername)
+        with open('main.go', 'x') as file:
+            file.write(templates.render('golang/main.go.tmpl'))
+        os.chdir('../..')
+        return 'DONE'
+
     os.chdir('src')
     if args.language == 'typescript':
 
@@ -130,35 +162,6 @@ app.listen(port, () => {
         os.chdir('..')
         return 'DONE'
 
-    if args.language == 'golang':
-        file = open('server.go', 'x')
-        server_code = """
-package main
-
-import (
-    "net/http"
-
-    "github.com/labstack/echo/v4"
-)
-
-func main() {
-    // Create an Echo instance
-    e := echo.New()
-
-    // Define a route
-    e.GET("/", func(c echo.Context) error {
-        return c.String(http.StatusOK, "Hello, Echo!")
-    })
-
-    // Start the server
-    e.Start(":8080")
-}
-"""
-        file.write(server_code) 
-        file.close()
-        os.chdir('..')
-        return 'DONE'
-
     return 'UNEXPECTED ERROR ENCOUNTERED'
 
 # create actions
@@ -176,33 +179,33 @@ def create_actions(args):
 
 # install dependencies
 def install_dependencies(args):
-    os.chdir('./src')
-    if args.language == 'typescript':
-        # TODO: getting dependencies from user
-        dependencies = [
-            'express', 
-            '@types/express',
-            'ts-node', 
-            'ts-dotenv',
-            'cors', 
-            'winston',
-            'helmet'
-        ]
-        for items in dependencies:
-            os.system('npm install ' + items)
-
-        os.chdir('..')
-        return 'DONE'
-
     if args.language == 'golang':
         # TODO: getting dependencies from user
         dependencies = [
             'github.com/labstack/echo/v4',
             'github.com/francoispqt/onelog',
-            'gorm.io/gorm'
+            'gorm.io/gorm',
+            'gorm.io/driver/mysql'
         ]
         for items in dependencies:
             os.system('go get -u ' + items)
+
+        return 'DONE'
+
+    os.chdir('./src')
+    if args.language == 'typescript':
+        # TODO: getting dependencies from user
+        dependencies = [
+            'express',
+            '@types/express',
+            'ts-node',
+            'ts-dotenv',
+            'cors',
+            'winston',
+            'helmet'
+        ]
+        for items in dependencies:
+            os.system('npm install ' + items)
 
         os.chdir('..')
         return 'DONE'

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-file_to_check = "./dist"
-second_file_to_check = "./build"
+file_to_check="./dist"
+second_file_to_check="./build"
 
 if [ -e "$file_to_check" ]; then
     echo "Your binary has already been built"
@@ -9,6 +9,6 @@ elif [ -e "$second_file_to_check" ]; then
     echo "Your binary has already been built"
 else
     pip3 install -r requirements.txt
-    mkdir ~/.codeseed
-    python3 -m PyInstaller --distpath=~/.codeseed --onefile codeseed.py
+    mkdir -p ~/.codeseed
+    python3 -m PyInstaller --distpath=~/.codeseed --onefile --add-data "templates:templates" codeseed.py
 fi

--- a/templates/golang/main.go.tmpl
+++ b/templates/golang/main.go.tmpl
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	// Create an Echo instance
+	e := echo.New()
+
+	// Define a route
+	e.GET("/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "Hello, Echo!")
+	})
+
+	// Start the server
+	e.Logger.Fatal(e.Start(":8080"))
+}

--- a/utils/templates.py
+++ b/utils/templates.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import string
+
+
+def _base_dir():
+    # PyInstaller --onefile extracts bundled data to sys._MEIPASS at runtime.
+    # In dev (python3 codeseed.py) there is no _MEIPASS, so fall back to the
+    # project root (parent of this utils/ folder).
+    if hasattr(sys, '_MEIPASS'):
+        return sys._MEIPASS
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+TEMPLATES_DIR = os.path.join(_base_dir(), 'templates')
+
+
+def render(relative_path, **kwargs):
+    template_path = os.path.join(TEMPLATES_DIR, *relative_path.split('/'))
+    with open(template_path, 'r') as f:
+        template = string.Template(f.read())
+    return template.substitute(**kwargs)


### PR DESCRIPTION
## Summary
- go.mod and cmd/<name>/main.go now live at project root instead of under src/ (carried over from the typescript path, never made sense for Go).
- install_dependencies unconditionally chdir'd into src/ regardless of language — would have broken outright on the next golang init once src/ was removed. Fixed to branch per language.
- Adds gorm.io/driver/mysql to the golang dependency list (was missing).
- Generated main.go now renders from templates/golang/main.go.tmpl via stdlib string.Template (utils/templates.py) instead of an inline Python string. install.sh bundles templates/ via --add-data.
- Fixed install.sh's broken variable assignment (invalid bash) and non-idempotent mkdir.

typescript path unaffected. First of several small PRs splitting out what was originally one large change (#44, now closed).

## Test plan
- [x] `python3 codeseed.py init <name> -l golang -r -s` — correct layout, `go build`/`go vet`/`gofmt` all clean
- [x] Verified against the frozen PyInstaller binary too (`--add-data` resolves via `_MEIPASS`)