### PR TITLE
feat: golang init generates GORM + MySQL database.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ internal/
 
 `codeseed create <name>` fills in a struct + constructor + empty interface per layer — method bodies are yours to write, not generated. The `inputport/` files carry a `go:generate mockgen` directive (`go.uber.org/mock`) so a mock is one `go generate ./...` away once the interface has methods on it.
 
+`internal/infrastructure/` is generated with a `database.go` (GORM + MySQL connection via `DB_*` env vars) on every golang init.
+
 ## Options
 ### Init argument options:
 | Option          | ShortHand | Description                                                                                             |

--- a/commands/init/init.py
+++ b/commands/init/init.py
@@ -15,6 +15,14 @@ def init_command(args):
         return
     print('CREATING FILES: ' + files)
 
+    # create database connection boilerplate (golang only — same setup every project)
+    if args.language == 'golang':
+        database = functions.create_database(args)
+        if database != 'DONE':
+            print('PROBLEM CREATING DATABASE FILE')
+            return
+        print('CREATING DATABASE FILE: ' + database)
+
     # create logger boilerplate (golang only — same setup every project)
     if args.language == 'golang':
         logger = functions.create_logger(args)

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -143,6 +143,12 @@ def create_dockerfile(args):
     os.chdir('..')
     return 'DONE'
 
+# create database connection boilerplate (golang only)
+def create_database(args):
+    with open('internal/infrastructure/database.go', 'x') as file:
+        file.write(templates.render('golang/database.go.tmpl'))
+    return 'DONE'
+
 # create serverfile
 def create_server(args):
     if args.language == 'golang':

--- a/templates/golang/database.go.tmpl
+++ b/templates/golang/database.go.tmpl
@@ -1,0 +1,28 @@
+package infrastructure
+
+import (
+	"fmt"
+	"os"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// Connection opens a MySQL connection using DB_* environment variables.
+func Connection() (*gorm.DB, error) {
+	dsn := fmt.Sprintf(
+		"%s:%s@tcp(%s:%s)/%s?parseTime=true",
+		os.Getenv("DB_USER"),
+		os.Getenv("DB_PASSWORD"),
+		os.Getenv("DB_HOST"),
+		os.Getenv("DB_PORT"),
+		os.Getenv("DB_NAME"),
+	)
+
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}


### PR DESCRIPTION
## Summary
- Every golang project needs the same GORM + MySQL connection setup, so `init` now always writes `internal/infrastructure/database.go` — unconditional, same as the `internal/infrastructure/` folder itself, no flag required.
- New `templates/golang/database.go.tmpl` (static, no `${}` vars) renders via the existing `templates.render` system from #45, matching the `main.go.tmpl` pattern.
- `Connection()` builds a DSN from `DB_USER`/`DB_PASSWORD`/`DB_HOST`/`DB_PORT`/`DB_NAME` env vars and opens it with `gorm.Open(mysql.Open(dsn), ...)`.

Depends on #45 (feature/COD-60) for the `cmd/`+`internal/` layout and `utils/templates.py`.

## Test plan
- [x] `init dbapp -l golang -r -s` — `internal/infrastructure/database.go` created with real content
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean on generated project
- [x] `init dbapp2 -l golang -s` (no `-r`) — `database.go` still written even when deps aren't installed, confirming file creation doesn't depend on `install_dependencies`
- [x] `init tsapp -l typescript -s` — database step correctly skipped for non-golang