### PR TITLE
feat: templatize init's remaining generated files, real golang Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ The `install.sh` script will create a `~/.codeseed` binary, you will have to exp
  ```
 
 #### Windows
-Currently the `install.sh` only works with unix like systems for windows run `python3 -m PyInstaller --onefile codeseed.py` 
+Currently the `install.sh` only works with unix like systems for windows run `python3 -m PyInstaller --onefile --add-data "templates;templates" codeseed.py`
 this will create a `dist` folder. Add the path to the `dist` folder to your Environment variables and restart your machine and you are good to go.
+
+> [!NOTE] *The `--add-data` flag is required — codeseed's generated file content lives in `templates/`, not hardcoded in the script, so the binary needs it bundled to work.*
 
 ## Usage
 Using CodeSeed is very easy. You just need to call codeseed on your terminal and add the name of the Backend project you want to create. Like the following.
@@ -84,6 +86,30 @@ codeseed init --language golang --url git@github.com:sabi1125/CodeSeed.git
 | ------     | ------------------------------------------------------- | ------------------------------------------ |
 | init       | Creates new project                                     | `codeseed init <project-name> --<options>` |
 | create     | Creates the controller, interactor and repository files | `codeseed create <filename>`               |
+
+### Project layout by language
+
+**typescript** keeps the original flat layout: everything under `src/` (`src/controller`, `src/repository`, `src/interfaces/interactor`, ...).
+
+**golang** does not use a `src/` layer — `go.mod` and `cmd/<project-name>/main.go` live at the project root, matching normal Go convention:
+
+```
+cmd/<project-name>/main.go
+internal/
+  controller/
+  domain/
+    entities/
+    interactor/
+      inputport/
+        mock/
+    repository/
+      inputport/
+        mock/
+  infrastructure/
+  response/
+  log/
+  util/
+```
 
 ## Options
 ### Init argument options:

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from utils import templates
+
 def create_dotfiles(args):
     config = {
         "language": args.language,
@@ -14,16 +16,41 @@ def create_dotfiles(args):
 
 # create folders
 def create_folders(args):
-    folder_paths = [
-        '/src', 
-        '/src/controller',
-        '/src/domain',
-        '/src/interfaces',
-        '/src/infrastructure',
-        '/src/interfaces/interactor',
-        '/src/repository',
-        '/src/model'
-    ]
+    if args.language == 'golang':
+        # golang doesn't use a src/ layer — go.mod and cmd/ live at project root.
+        # domain/interactor and domain/repository each carry an inputport/ (the
+        # interface the layer above depends on, not the concrete type) plus an
+        # inputport/mock/ for generated mocks — dependency inversion, not just
+        # controller/interactor/repository as flat siblings.
+        folder_paths = [
+            '/cmd',
+            '/cmd/' + args.foldername,
+            '/internal',
+            '/internal/controller',
+            '/internal/domain',
+            '/internal/domain/entities',
+            '/internal/domain/interactor',
+            '/internal/domain/interactor/inputport',
+            '/internal/domain/interactor/inputport/mock',
+            '/internal/domain/repository',
+            '/internal/domain/repository/inputport',
+            '/internal/domain/repository/inputport/mock',
+            '/internal/infrastructure',
+            '/internal/response',
+            '/internal/log',
+            '/internal/util'
+        ]
+    else:
+        folder_paths = [
+            '/src',
+            '/src/controller',
+            '/src/domain',
+            '/src/interfaces',
+            '/src/infrastructure',
+            '/src/interfaces/interactor',
+            '/src/repository',
+            '/src/model'
+        ]
 
     list_of_directory = os.listdir("./")
     dir_already_exists = False
@@ -73,9 +100,7 @@ def create_files(args):
     
 
     if args.language == 'golang':
-        os.chdir('./src')
         os.system('go mod init ' + args.foldername)
-        os.chdir('..')
         return 'DONE'
 
 
@@ -107,6 +132,13 @@ def create_dockerfile(args):
 
 # create serverfile
 def create_server(args):
+    if args.language == 'golang':
+        os.chdir('cmd/' + args.foldername)
+        with open('main.go', 'x') as file:
+            file.write(templates.render('golang/main.go.tmpl'))
+        os.chdir('../..')
+        return 'DONE'
+
     os.chdir('src')
     if args.language == 'typescript':
 
@@ -130,35 +162,6 @@ app.listen(port, () => {
         os.chdir('..')
         return 'DONE'
 
-    if args.language == 'golang':
-        file = open('server.go', 'x')
-        server_code = """
-package main
-
-import (
-    "net/http"
-
-    "github.com/labstack/echo/v4"
-)
-
-func main() {
-    // Create an Echo instance
-    e := echo.New()
-
-    // Define a route
-    e.GET("/", func(c echo.Context) error {
-        return c.String(http.StatusOK, "Hello, Echo!")
-    })
-
-    // Start the server
-    e.Start(":8080")
-}
-"""
-        file.write(server_code) 
-        file.close()
-        os.chdir('..')
-        return 'DONE'
-
     return 'UNEXPECTED ERROR ENCOUNTERED'
 
 # create actions
@@ -176,33 +179,33 @@ def create_actions(args):
 
 # install dependencies
 def install_dependencies(args):
-    os.chdir('./src')
-    if args.language == 'typescript':
-        # TODO: getting dependencies from user
-        dependencies = [
-            'express', 
-            '@types/express',
-            'ts-node', 
-            'ts-dotenv',
-            'cors', 
-            'winston',
-            'helmet'
-        ]
-        for items in dependencies:
-            os.system('npm install ' + items)
-
-        os.chdir('..')
-        return 'DONE'
-
     if args.language == 'golang':
         # TODO: getting dependencies from user
         dependencies = [
             'github.com/labstack/echo/v4',
             'github.com/francoispqt/onelog',
-            'gorm.io/gorm'
+            'gorm.io/gorm',
+            'gorm.io/driver/mysql'
         ]
         for items in dependencies:
             os.system('go get -u ' + items)
+
+        return 'DONE'
+
+    os.chdir('./src')
+    if args.language == 'typescript':
+        # TODO: getting dependencies from user
+        dependencies = [
+            'express',
+            '@types/express',
+            'ts-node',
+            'ts-dotenv',
+            'cors',
+            'winston',
+            'helmet'
+        ]
+        for items in dependencies:
+            os.system('npm install ' + items)
 
         os.chdir('..')
         return 'DONE'

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -85,19 +85,20 @@ def create_files(args):
     # creating gitignore file
     if 'git' in args.ignoreconfig:
         print("CREATING: gitignore")
-        with open('.gitignore', "w"):
-            pass
+        if args.language == 'golang':
+            gitignore_content = templates.render('golang/gitignore.tmpl', foldername=args.foldername)
+        else:
+            gitignore_content = templates.render('typescript/gitignore.tmpl')
+        with open('.gitignore', "w") as file:
+            file.write(gitignore_content)
 
     if args.language == 'typescript':
-        file = open('.gitignore', "w")
-        file.write('src/node_modules')
-        file.close()
         os.chdir('./src')
         os.system('npm i typescript --save-dev')
         os.system('npx tsc --init')
         os.chdir('..')
         return 'DONE'
-    
+
 
     if args.language == 'golang':
         os.system('go mod init ' + args.foldername)
@@ -110,12 +111,17 @@ def create_files(args):
 # create dockerfile
 def create_dockerfile(args):
     docker_compose_file = open('docker-compose.yml', 'x')
-    docker_compose_file.write('#write your docker compose file here')
+    docker_compose_file.write(templates.render('shared/docker-compose.yml.tmpl'))
     docker_compose_file.close()
     os.chdir('docker')
 
+    if args.language == 'golang':
+        dockerfile_content = templates.render('golang/Dockerfile.tmpl', foldername=args.foldername)
+    else:
+        dockerfile_content = templates.render('typescript/Dockerfile.tmpl')
+
     dockerfile = open('DOCKERFILE', 'x')
-    dockerfile.write('#write you dockerfile here')
+    dockerfile.write(dockerfile_content)
     dockerfile.close()
     os.chdir('..')
     if 'docker' in args.ignoreconfig:
@@ -125,7 +131,7 @@ def create_dockerfile(args):
     os.mkdir('scripts')
     os.chdir('scripts')
     file = open('entrypoint.sh', 'x')
-    file.write('// script file')
+    file.write(templates.render('shared/entrypoint.sh.tmpl'))
     file.close()
     os.chdir('..')
     return 'DONE'
@@ -143,21 +149,7 @@ def create_server(args):
     if args.language == 'typescript':
 
         file = open('server.ts', 'x')
-        server_code = """
-import express from 'express';
-
-const app = express();
-const port = 3000;
-
-app.get('/', (req, res) => {
-  res.send('Hello, Express!');
-});
-
-app.listen(port, () => {
-  console.log(`Server is running on port ${port}`);
-});
-        """
-        file.write(server_code)
+        file.write(templates.render('typescript/server.ts.tmpl'))
         file.close()
         os.chdir('..')
         return 'DONE'
@@ -170,7 +162,7 @@ def create_actions(args):
     os.mkdir('.github/workflows')
     os.chdir('.github/workflows')
     file = open('actions.yml', 'x')
-    file.write('# your github-actions go here')
+    file.write(templates.render('shared/actions.yml.tmpl'))
     file.close()
     os.chdir('..')
     os.chdir('..')

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-file_to_check = "./dist"
-second_file_to_check = "./build"
+file_to_check="./dist"
+second_file_to_check="./build"
 
 if [ -e "$file_to_check" ]; then
     echo "Your binary has already been built"
@@ -9,6 +9,6 @@ elif [ -e "$second_file_to_check" ]; then
     echo "Your binary has already been built"
 else
     pip3 install -r requirements.txt
-    mkdir ~/.codeseed
-    python3 -m PyInstaller --distpath=~/.codeseed --onefile codeseed.py
+    mkdir -p ~/.codeseed
+    python3 -m PyInstaller --distpath=~/.codeseed --onefile --add-data "templates:templates" codeseed.py
 fi

--- a/templates/golang/Dockerfile.tmpl
+++ b/templates/golang/Dockerfile.tmpl
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /app/bin/${foldername} ./cmd/${foldername}
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=build /app/bin/${foldername} ./${foldername}
+EXPOSE 8080
+ENTRYPOINT ["./${foldername}"]

--- a/templates/golang/gitignore.tmpl
+++ b/templates/golang/gitignore.tmpl
@@ -1,0 +1,3 @@
+/${foldername}
+.env
+vendor/

--- a/templates/golang/main.go.tmpl
+++ b/templates/golang/main.go.tmpl
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	// Create an Echo instance
+	e := echo.New()
+
+	// Define a route
+	e.GET("/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "Hello, Echo!")
+	})
+
+	// Start the server
+	e.Logger.Fatal(e.Start(":8080"))
+}

--- a/templates/shared/actions.yml.tmpl
+++ b/templates/shared/actions.yml.tmpl
@@ -1,0 +1,1 @@
+# your github-actions go here

--- a/templates/shared/docker-compose.yml.tmpl
+++ b/templates/shared/docker-compose.yml.tmpl
@@ -1,0 +1,1 @@
+#write your docker compose file here

--- a/templates/shared/entrypoint.sh.tmpl
+++ b/templates/shared/entrypoint.sh.tmpl
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+exec "$$@"

--- a/templates/typescript/Dockerfile.tmpl
+++ b/templates/typescript/Dockerfile.tmpl
@@ -1,0 +1,1 @@
+#write you dockerfile here

--- a/templates/typescript/gitignore.tmpl
+++ b/templates/typescript/gitignore.tmpl
@@ -1,0 +1,1 @@
+src/node_modules

--- a/templates/typescript/server.ts.tmpl
+++ b/templates/typescript/server.ts.tmpl
@@ -1,0 +1,14 @@
+
+import express from 'express';
+
+const app = express();
+const port = 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello, Express!');
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port $${port}`);
+});
+        

--- a/utils/templates.py
+++ b/utils/templates.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import string
+
+
+def _base_dir():
+    # PyInstaller --onefile extracts bundled data to sys._MEIPASS at runtime.
+    # In dev (python3 codeseed.py) there is no _MEIPASS, so fall back to the
+    # project root (parent of this utils/ folder).
+    if hasattr(sys, '_MEIPASS'):
+        return sys._MEIPASS
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+TEMPLATES_DIR = os.path.join(_base_dir(), 'templates')
+
+
+def render(relative_path, **kwargs):
+    template_path = os.path.join(TEMPLATES_DIR, *relative_path.split('/'))
+    with open(template_path, 'r') as f:
+        template = string.Template(f.read())
+    return template.substitute(**kwargs)


### PR DESCRIPTION
## Summary
- Moves the last inline-Python-string generated content in `commands/init/init_functions.py` into `templates/`, rendered via `utils/templates.render` (same pattern as `main.go.tmpl` in #45).
- golang's `docker/DOCKERFILE` is now a real multi-stage build (`golang:1.25-alpine` builder -> `alpine` runtime, builds `./cmd/<foldername>`, `EXPOSE 8080`) instead of a placeholder.
- `scripts/entrypoint.sh` was `'// script file'` for both languages -- invalid shell syntax (`//` isn't a comment in `sh`). Replaced with a real shared passthrough entrypoint template.
- golang's `.gitignore` now has real content (binary, `.env`, `vendor/`) instead of an empty stub; typescript's inline `src/node_modules` moved to a template. Both are now consistently gated on `'git' in args.ignoreconfig` (typescript previously wrote `.gitignore` unconditionally, ignoring the flag).
- typescript's inline Express `server.ts` moved to a template verbatim, with its JS template-literal `${port}` escaped as `$${port}` so Python's `string.Template` passes it through literally.
- github actions placeholder moved to `templates/shared/actions.yml.tmpl`.
- `docker-compose.yml` stays an intentional placeholder -- compose files are too project-specific to template meaningfully -- just relocated into `templates/shared/docker-compose.yml.tmpl`.

Depends on #45 (branched from `feature/COD-60`, needs the folder layout and `utils/templates.py` it introduced).

## Test plan
- [x] `codeseed init goapp -l golang -d -r -s --ignore-config git` -- generated `.gitignore`, `docker/DOCKERFILE`, `scripts/entrypoint.sh` all render correctly, no template exceptions
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean on generated golang output
- [x] `docker build -f docker/DOCKERFILE -t cs-test-go .` actually succeeds against the generated project (image built and removed after)
- [x] `codeseed init tsapp -l typescript -d -s --ignore-config git` -- generated `.gitignore`, `docker/DOCKERFILE`, `scripts/entrypoint.sh`, `src/server.ts` all render correctly
- [x] Confirmed generated `server.ts` is byte-identical to the previous inline string, with the literal `${port}` in the console.log line intact (not empty, not KeyError, not mangled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)