### PR TITLE
feat: golang init generates a zap-based structured logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ internal/
         mock/
   infrastructure/
   response/
-  log/
+  log/           # generated logger.go — zap, configured via LOG_LEVEL/APP_ENV env vars
   util/
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ The `install.sh` script will create a `~/.codeseed` binary, you will have to exp
  ```
 
 #### Windows
-Currently the `install.sh` only works with unix like systems for windows run `python3 -m PyInstaller --onefile codeseed.py` 
+Currently the `install.sh` only works with unix like systems for windows run `python3 -m PyInstaller --onefile --add-data "templates;templates" codeseed.py`
 this will create a `dist` folder. Add the path to the `dist` folder to your Environment variables and restart your machine and you are good to go.
+
+> [!NOTE] *The `--add-data` flag is required — codeseed's generated file content lives in `templates/`, not hardcoded in the script, so the binary needs it bundled to work.*
 
 ## Usage
 Using CodeSeed is very easy. You just need to call codeseed on your terminal and add the name of the Backend project you want to create. Like the following.
@@ -84,6 +86,30 @@ codeseed init --language golang --url git@github.com:sabi1125/CodeSeed.git
 | ------     | ------------------------------------------------------- | ------------------------------------------ |
 | init       | Creates new project                                     | `codeseed init <project-name> --<options>` |
 | create     | Creates the controller, interactor and repository files | `codeseed create <filename>`               |
+
+### Project layout by language
+
+**typescript** keeps the original flat layout: everything under `src/` (`src/controller`, `src/repository`, `src/interfaces/interactor`, ...).
+
+**golang** does not use a `src/` layer — `go.mod` and `cmd/<project-name>/main.go` live at the project root, matching normal Go convention:
+
+```
+cmd/<project-name>/main.go
+internal/
+  controller/
+  domain/
+    entities/
+    interactor/
+      inputport/
+        mock/
+    repository/
+      inputport/
+        mock/
+  infrastructure/
+  response/
+  log/
+  util/
+```
 
 ## Options
 ### Init argument options:

--- a/commands/init/init.py
+++ b/commands/init/init.py
@@ -15,6 +15,14 @@ def init_command(args):
         return
     print('CREATING FILES: ' + files)
 
+    # create logger boilerplate (golang only — same setup every project)
+    if args.language == 'golang':
+        logger = functions.create_logger(args)
+        if logger != 'DONE':
+            print('PROBLEM CREATING LOGGER FILE')
+            return
+        print('CREATING LOGGER FILE: ' + logger)
+
     # create docker files
     if args.docker:
         dockerfile = functions.create_dockerfile(args)

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -1,6 +1,8 @@
 import os
 import json
 
+from utils import templates
+
 def create_dotfiles(args):
     config = {
         "language": args.language,
@@ -14,16 +16,41 @@ def create_dotfiles(args):
 
 # create folders
 def create_folders(args):
-    folder_paths = [
-        '/src', 
-        '/src/controller',
-        '/src/domain',
-        '/src/interfaces',
-        '/src/infrastructure',
-        '/src/interfaces/interactor',
-        '/src/repository',
-        '/src/model'
-    ]
+    if args.language == 'golang':
+        # golang doesn't use a src/ layer — go.mod and cmd/ live at project root.
+        # domain/interactor and domain/repository each carry an inputport/ (the
+        # interface the layer above depends on, not the concrete type) plus an
+        # inputport/mock/ for generated mocks — dependency inversion, not just
+        # controller/interactor/repository as flat siblings.
+        folder_paths = [
+            '/cmd',
+            '/cmd/' + args.foldername,
+            '/internal',
+            '/internal/controller',
+            '/internal/domain',
+            '/internal/domain/entities',
+            '/internal/domain/interactor',
+            '/internal/domain/interactor/inputport',
+            '/internal/domain/interactor/inputport/mock',
+            '/internal/domain/repository',
+            '/internal/domain/repository/inputport',
+            '/internal/domain/repository/inputport/mock',
+            '/internal/infrastructure',
+            '/internal/response',
+            '/internal/log',
+            '/internal/util'
+        ]
+    else:
+        folder_paths = [
+            '/src',
+            '/src/controller',
+            '/src/domain',
+            '/src/interfaces',
+            '/src/infrastructure',
+            '/src/interfaces/interactor',
+            '/src/repository',
+            '/src/model'
+        ]
 
     list_of_directory = os.listdir("./")
     dir_already_exists = False
@@ -73,9 +100,7 @@ def create_files(args):
     
 
     if args.language == 'golang':
-        os.chdir('./src')
         os.system('go mod init ' + args.foldername)
-        os.chdir('..')
         return 'DONE'
 
 
@@ -107,6 +132,13 @@ def create_dockerfile(args):
 
 # create serverfile
 def create_server(args):
+    if args.language == 'golang':
+        os.chdir('cmd/' + args.foldername)
+        with open('main.go', 'x') as file:
+            file.write(templates.render('golang/main.go.tmpl'))
+        os.chdir('../..')
+        return 'DONE'
+
     os.chdir('src')
     if args.language == 'typescript':
 
@@ -130,35 +162,6 @@ app.listen(port, () => {
         os.chdir('..')
         return 'DONE'
 
-    if args.language == 'golang':
-        file = open('server.go', 'x')
-        server_code = """
-package main
-
-import (
-    "net/http"
-
-    "github.com/labstack/echo/v4"
-)
-
-func main() {
-    // Create an Echo instance
-    e := echo.New()
-
-    // Define a route
-    e.GET("/", func(c echo.Context) error {
-        return c.String(http.StatusOK, "Hello, Echo!")
-    })
-
-    // Start the server
-    e.Start(":8080")
-}
-"""
-        file.write(server_code) 
-        file.close()
-        os.chdir('..')
-        return 'DONE'
-
     return 'UNEXPECTED ERROR ENCOUNTERED'
 
 # create actions
@@ -176,33 +179,33 @@ def create_actions(args):
 
 # install dependencies
 def install_dependencies(args):
-    os.chdir('./src')
-    if args.language == 'typescript':
-        # TODO: getting dependencies from user
-        dependencies = [
-            'express', 
-            '@types/express',
-            'ts-node', 
-            'ts-dotenv',
-            'cors', 
-            'winston',
-            'helmet'
-        ]
-        for items in dependencies:
-            os.system('npm install ' + items)
-
-        os.chdir('..')
-        return 'DONE'
-
     if args.language == 'golang':
         # TODO: getting dependencies from user
         dependencies = [
             'github.com/labstack/echo/v4',
             'github.com/francoispqt/onelog',
-            'gorm.io/gorm'
+            'gorm.io/gorm',
+            'gorm.io/driver/mysql'
         ]
         for items in dependencies:
             os.system('go get -u ' + items)
+
+        return 'DONE'
+
+    os.chdir('./src')
+    if args.language == 'typescript':
+        # TODO: getting dependencies from user
+        dependencies = [
+            'express',
+            '@types/express',
+            'ts-node',
+            'ts-dotenv',
+            'cors',
+            'winston',
+            'helmet'
+        ]
+        for items in dependencies:
+            os.system('npm install ' + items)
 
         os.chdir('..')
         return 'DONE'

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -107,6 +107,13 @@ def create_files(args):
     return 'UNEXPECTED ERROR ENCOUNTERED'
 
 
+# create logger boilerplate (golang only — same setup every project)
+def create_logger(args):
+    with open('internal/log/logger.go', 'x') as file:
+        file.write(templates.render('golang/logger.go.tmpl'))
+    return 'DONE'
+
+
 # create dockerfile
 def create_dockerfile(args):
     docker_compose_file = open('docker-compose.yml', 'x')
@@ -185,7 +192,8 @@ def install_dependencies(args):
             'github.com/labstack/echo/v4',
             'github.com/francoispqt/onelog',
             'gorm.io/gorm',
-            'gorm.io/driver/mysql'
+            'gorm.io/driver/mysql',
+            'go.uber.org/zap'
         ]
         for items in dependencies:
             os.system('go get -u ' + items)

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-file_to_check = "./dist"
-second_file_to_check = "./build"
+file_to_check="./dist"
+second_file_to_check="./build"
 
 if [ -e "$file_to_check" ]; then
     echo "Your binary has already been built"
@@ -9,6 +9,6 @@ elif [ -e "$second_file_to_check" ]; then
     echo "Your binary has already been built"
 else
     pip3 install -r requirements.txt
-    mkdir ~/.codeseed
-    python3 -m PyInstaller --distpath=~/.codeseed --onefile codeseed.py
+    mkdir -p ~/.codeseed
+    python3 -m PyInstaller --distpath=~/.codeseed --onefile --add-data "templates:templates" codeseed.py
 fi

--- a/templates/golang/logger.go.tmpl
+++ b/templates/golang/logger.go.tmpl
@@ -1,0 +1,113 @@
+package logger
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var log *zap.Logger
+
+// Init initializes the logger from LOG_LEVEL and APP_ENV environment variables.
+func Init() {
+	var level zapcore.Level
+	if err := level.UnmarshalText([]byte(os.Getenv("LOG_LEVEL"))); err != nil {
+		level = zapcore.InfoLevel
+	}
+
+	isDevelopment := os.Getenv("APP_ENV") == "development"
+	encoding := "json"
+	if isDevelopment {
+		encoding = "console"
+	}
+
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "message",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+
+	config := zap.Config{
+		Level:            zap.NewAtomicLevelAt(level),
+		Development:      isDevelopment,
+		Encoding:         encoding,
+		EncoderConfig:    encoderConfig,
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
+
+	built, err := config.Build()
+	if err != nil {
+		panic("failed to build logger: " + err.Error())
+	}
+
+	log = built
+}
+
+// Get returns the underlying *zap.Logger, for callers that need direct access.
+func Get() *zap.Logger {
+	return log
+}
+
+// Sync flushes any buffered log entries — call before process exit.
+func Sync() {
+	log.Sync()
+}
+
+func Info(msg string, fields ...zap.Field) {
+	log.Info(msg, fields...)
+}
+
+func Infow(msg string, fields ...interface{}) {
+	log.Sugar().Infow(msg, fields...)
+}
+
+func Infof(templateString string, fields ...interface{}) {
+	log.Sugar().Infof(templateString, fields...)
+}
+
+func Warn(msg string, fields ...zap.Field) {
+	log.Warn(msg, fields...)
+}
+
+func Warnw(msg string, fields ...interface{}) {
+	log.Sugar().Warnw(msg, fields...)
+}
+
+func Warnf(templateString string, fields ...interface{}) {
+	log.Sugar().Warnf(templateString, fields...)
+}
+
+func Error(err error, fields ...zap.Field) {
+	log.Error(err.Error(), fields...)
+}
+
+func Errorw(msg string, err error, fields ...interface{}) {
+	log.Sugar().Errorw(msg, append(fields, "error", err.Error())...)
+}
+
+func Fatal(msg string, fields ...zap.Field) {
+	log.Fatal(msg, fields...)
+}
+
+func Fatalf(templateString string, fields ...interface{}) {
+	log.Sugar().Fatalf(templateString, fields...)
+}
+
+func Panic(msg string, fields ...zap.Field) {
+	log.Panic(msg, fields...)
+}
+
+// InitForTest sets up a no-op logger for use in tests.
+func InitForTest() {
+	log = zap.NewNop()
+}

--- a/templates/golang/main.go.tmpl
+++ b/templates/golang/main.go.tmpl
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	// Create an Echo instance
+	e := echo.New()
+
+	// Define a route
+	e.GET("/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "Hello, Echo!")
+	})
+
+	// Start the server
+	e.Logger.Fatal(e.Start(":8080"))
+}

--- a/utils/templates.py
+++ b/utils/templates.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import string
+
+
+def _base_dir():
+    # PyInstaller --onefile extracts bundled data to sys._MEIPASS at runtime.
+    # In dev (python3 codeseed.py) there is no _MEIPASS, so fall back to the
+    # project root (parent of this utils/ folder).
+    if hasattr(sys, '_MEIPASS'):
+        return sys._MEIPASS
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+TEMPLATES_DIR = os.path.join(_base_dir(), 'templates')
+
+
+def render(relative_path, **kwargs):
+    template_path = os.path.join(TEMPLATES_DIR, *relative_path.split('/'))
+    with open(template_path, 'r') as f:
+        template = string.Template(f.read())
+    return template.substitute(**kwargs)


### PR DESCRIPTION
## Summary
- `internal/log/logger.go` now generated unconditionally on golang `init`, same as `database.go` (#47) — same setup every project needs, no flag required.
- Adapted from a zap wrapper used in another one of my projects, stripped down to what's actually portable: no Gin middleware (this stack is Echo), no project-specific status/error coupling, no injected config struct. Reads `LOG_LEVEL`/`APP_ENV` directly from env, matching `database.go`'s `DB_*` convention.
- Surface: `Init`/`Get`/`Sync`, `Info`/`Infow`/`Infof`, `Warn`/`Warnw`/`Warnf`, `Error`/`Errorw`, `Fatal`/`Fatalf`, `Panic`, `InitForTest` (no-op logger for tests).
- Adds `go.uber.org/zap` to the golang dependency list.

Depends on #45 (feature/COD-60) for the `cmd/`+`internal/` layout and `utils/templates.py`.

## Test plan
- [x] `init logtest -l golang -r -s` — `logger.go` generated, `go build`/`go vet`/`gofmt` all clean
- [x] Functional smoke test — actually called `Init`/`Info`/`Warn`/`Error`/`Infow`/`Sync`, confirmed real JSON output with correct levels, structured fields, and stacktrace on error
- [x] Confirmed `LOG_LEVEL=warn` actually filters output, and `APP_ENV=development` actually switches to console encoding