### PR TITLE
fix: main.go never called logger.Init(), nil pointer panic waiting to happen

### DIFF
--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -155,7 +155,7 @@ def create_server(args):
     if args.language == 'golang':
         os.chdir('cmd/' + args.foldername)
         with open('main.go', 'x') as file:
-            file.write(templates.render('golang/main.go.tmpl'))
+            file.write(templates.render('golang/main.go.tmpl', module=args.foldername))
         os.chdir('../..')
         return 'DONE'
 

--- a/templates/golang/main.go.tmpl
+++ b/templates/golang/main.go.tmpl
@@ -3,10 +3,15 @@ package main
 import (
 	"net/http"
 
+	"${module}/internal/log"
+
 	"github.com/labstack/echo/v4"
 )
 
 func main() {
+	logger.Init()
+	defer logger.Sync()
+
 	// Create an Echo instance
 	e := echo.New()
 
@@ -16,5 +21,6 @@ func main() {
 	})
 
 	// Start the server
+	logger.Info("starting server")
 	e.Logger.Fatal(e.Start(":8080"))
 }


### PR DESCRIPTION
## Summary
`logger.go` generates a package-level `*zap.Logger` that stays `nil` until `Init()` runs — nothing in the generated code ever called it, so the first `logger.Info()`/`Warn()`/etc from user code would nil-pointer panic. Wires `logger.Init()` + `defer logger.Sync()` into `main.go`, plus a real `logger.Info("starting server")` call before Echo starts.

`main.go.tmpl` now needs the module name to import the project's own `internal/log` package, so `create_server` passes `module=args.foldername`, same as the other layer templates already do.

## Test plan
- [x] `go build`/`go vet`/`gofmt` clean
- [x] Actually ran the generated server (`go run ./cmd/<name>`) — confirmed the JSON log line fires before Echo's startup banner, not just that it compiles