### PR TITLE
feat: golang init generates a transaction manager

### DIFF
--- a/commands/init/init.py
+++ b/commands/init/init.py
@@ -23,6 +23,14 @@ def init_command(args):
             return
         print('CREATING DATABASE FILE: ' + database)
 
+    # create transaction manager boilerplate (golang only — same setup every project)
+    if args.language == 'golang':
+        transaction = functions.create_transaction(args)
+        if transaction != 'DONE':
+            print('PROBLEM CREATING TRANSACTION FILE')
+            return
+        print('CREATING TRANSACTION FILE: ' + transaction)
+
     # create logger boilerplate (golang only — same setup every project)
     if args.language == 'golang':
         logger = functions.create_logger(args)

--- a/commands/init/init.py
+++ b/commands/init/init.py
@@ -25,6 +25,12 @@ def init_command(args):
 
     # create transaction manager boilerplate (golang only — same setup every project)
     if args.language == 'golang':
+        tx_manager = functions.create_tx_manager(args)
+        if tx_manager != 'DONE':
+            print('PROBLEM CREATING TRANSACTION MANAGER INTERFACE FILE')
+            return
+        print('CREATING TRANSACTION MANAGER INTERFACE FILE: ' + tx_manager)
+
         transaction = functions.create_transaction(args)
         if transaction != 'DONE':
             print('PROBLEM CREATING TRANSACTION FILE')

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -150,6 +150,12 @@ def create_database(args):
         file.write(templates.render('golang/database.go.tmpl'))
     return 'DONE'
 
+# create transaction manager boilerplate (golang only)
+def create_transaction(args):
+    with open('internal/infrastructure/transaction.go', 'x') as file:
+        file.write(templates.render('golang/transaction.go.tmpl'))
+    return 'DONE'
+
 # create serverfile
 def create_server(args):
     if args.language == 'golang':

--- a/commands/init/init_functions.py
+++ b/commands/init/init_functions.py
@@ -39,6 +39,7 @@ def create_folders(args):
             '/internal/infrastructure',
             '/internal/response',
             '/internal/log',
+            '/internal/tx',
             '/internal/util'
         ]
     else:
@@ -150,10 +151,19 @@ def create_database(args):
         file.write(templates.render('golang/database.go.tmpl'))
     return 'DONE'
 
-# create transaction manager boilerplate (golang only)
+# create transaction manager boilerplate (golang only). Manager lives in its
+# own internal/tx package (interface only) so the domain layer can depend on
+# it without importing internal/infrastructure — same split as
+# interactor/repository inputport.
+def create_tx_manager(args):
+    with open('internal/tx/manager.go', 'x') as file:
+        file.write(templates.render('golang/tx_manager.go.tmpl'))
+    return 'DONE'
+
+
 def create_transaction(args):
     with open('internal/infrastructure/transaction.go', 'x') as file:
-        file.write(templates.render('golang/transaction.go.tmpl'))
+        file.write(templates.render('golang/transaction.go.tmpl', module=args.foldername))
     return 'DONE'
 
 # create serverfile

--- a/templates/golang/transaction.go.tmpl
+++ b/templates/golang/transaction.go.tmpl
@@ -3,6 +3,8 @@ package infrastructure
 import (
 	"context"
 
+	"${module}/internal/tx"
+
 	"gorm.io/gorm"
 )
 
@@ -10,17 +12,11 @@ type contextKey string
 
 const txKey contextKey = "gorm_tx"
 
-// Manager lets a caller run a function inside a single database transaction
-// without that function needing to know about *gorm.DB directly.
-type Manager interface {
-	WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error
-}
-
 type TransactionManager struct {
 	db *gorm.DB
 }
 
-func NewTransactionManager(db *gorm.DB) Manager {
+func NewTransactionManager(db *gorm.DB) tx.Manager {
 	return &TransactionManager{
 		db: db,
 	}
@@ -38,6 +34,6 @@ func (m *TransactionManager) WithinTransaction(ctx context.Context, fn func(ctx 
 // own db when nil, so repository methods work the same whether or not
 // they're running inside a transaction.
 func ExtractTx(ctx context.Context) *gorm.DB {
-	tx, _ := ctx.Value(txKey).(*gorm.DB)
-	return tx
+	gormTx, _ := ctx.Value(txKey).(*gorm.DB)
+	return gormTx
 }

--- a/templates/golang/transaction.go.tmpl
+++ b/templates/golang/transaction.go.tmpl
@@ -1,0 +1,43 @@
+package infrastructure
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type contextKey string
+
+const txKey contextKey = "gorm_tx"
+
+// Manager lets a caller run a function inside a single database transaction
+// without that function needing to know about *gorm.DB directly.
+type Manager interface {
+	WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error
+}
+
+type TransactionManager struct {
+	db *gorm.DB
+}
+
+func NewTransactionManager(db *gorm.DB) Manager {
+	return &TransactionManager{
+		db: db,
+	}
+}
+
+func (m *TransactionManager) WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error {
+	return m.db.WithContext(ctx).Transaction(func(gormTx *gorm.DB) error {
+		txCtx := context.WithValue(ctx, txKey, gormTx)
+		return fn(txCtx)
+	})
+}
+
+// ExtractTx returns the transaction-scoped *gorm.DB stashed in ctx by
+// WithinTransaction, or nil if there isn't one — callers fall back to their
+// own db when nil, so repository methods work the same whether or not
+// they're running inside a transaction.
+func ExtractTx(ctx context.Context) *gorm.DB {
+	tx, _ := ctx.Value(txKey).(*gorm.DB)
+	return tx
+}

--- a/templates/golang/tx_manager.go.tmpl
+++ b/templates/golang/tx_manager.go.tmpl
@@ -1,0 +1,12 @@
+package tx
+
+import "context"
+
+// Manager lets a caller run a function inside a single database transaction
+// without that function needing to know about *gorm.DB directly. Lives in
+// its own package so the domain layer (interactors) can depend on this
+// interface without importing internal/infrastructure — same reasoning as
+// the interactor/repository inputport split.
+type Manager interface {
+	WithinTransaction(ctx context.Context, fn func(ctx context.Context) error) error
+}


### PR DESCRIPTION
## Summary
Adapted from a pattern used in another one of my projects — unlike the logger (#49), this one was already framework-agnostic (pure `context.Context` + gorm, nothing to strip). `internal/infrastructure/transaction.go` generated unconditionally on golang `init`, same as `database.go` (#47) — it directly extends it (same `*gorm.DB`), same treatment.

- `Manager.WithinTransaction(ctx, fn)` runs `fn` inside a single transaction.
- `ExtractTx(ctx)` pulls the transaction-scoped `*gorm.DB` back out of context, or `nil` if there isn't one — repository methods work the same whether or not they're running inside a transaction:
  ```go
  db := infrastructure.ExtractTx(ctx)
  if db == nil { db = r.db }
  ```
- Simplified while porting: the original `ExtractTx` took a fallback `db` parameter it never actually used (both branches returned the same value regardless), so callers had to do the nil-check themselves anyway. Dropped the dead parameter.

## Test plan
- [x] `go build`/`go vet`/`gofmt` clean
- [x] Actually exercised it against a real in-memory sqlite database (not part of generated code, just for testing this PR): confirmed commit persists, rollback actually rolls back (1 row not 2), `ExtractTx` returns `nil` correctly outside any transaction