### PR TITLE
fix: install.sh silently skips rebuild if dist/build already exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
 
-file_to_check="./dist"
-second_file_to_check="./build"
+# dist/ and build/ are PyInstaller's own workspace — always start clean so a
+# re-run (updating an existing install) doesn't get blocked by leftovers from
+# a previous build (or a build that crashed partway through).
+rm -rf ./dist ./build
 
-if [ -e "$file_to_check" ]; then
-    echo "Your binary has already been built"
-elif [ -e "$second_file_to_check" ]; then
-    echo "Your binary has already been built"
-else
-    pip3 install -r requirements.txt
-    mkdir -p ~/.codeseed
-    python3 -m PyInstaller --distpath=~/.codeseed --onefile --add-data "templates:templates" codeseed.py
-fi
+pip3 install -r requirements.txt
+mkdir -p ~/.codeseed
+python3 -m PyInstaller --distpath=~/.codeseed --onefile --add-data "templates:templates" codeseed.py


### PR DESCRIPTION
## Summary
The dist/build existence check couldn't tell "already built, nothing changed" apart from "leftover from a previous run" or "crashed mid-build" — any of those left `install.sh` permanently refusing to rebuild until the folders were manually deleted. That defeats the actual point of running it a second time (updating an existing install).

`dist/`/`build/` are PyInstaller's own workspace, not meant to persist between runs — clean them at the start instead of guarding on their existence, so the script is idempotent regardless of what a previous run left behind.

(Found this because I had a stray `build/` left over in my own working copy from testing earlier PRs — same failure mode as a crashed build would cause.)

## Test plan
- [x] Simulated the exact failure: created stale `build/`/`dist/` folders, ran `install.sh` — it rebuilt anyway (binary mtime updated), instead of silently no-op'ing
- [x] Verified the freshly rebuilt `codeseed` binary still works (`init`/`create` both ran correctly against it)